### PR TITLE
Update plotly_streaming_cc3000.cpp

### DIFF
--- a/plotly_streaming_cc3000/plotly_streaming_cc3000.cpp
+++ b/plotly_streaming_cc3000/plotly_streaming_cc3000.cpp
@@ -42,7 +42,7 @@ bool plotly::init(){
     uint32_t ip = 0;
     Serial.print(F("... Attempting to resolve IP address of plot.ly"));
     while  (ip  ==  0)  {
-        if  (!  cc3000.getHostByName("www.plot.ly\n", &ip))  {
+        if  (!  cc3000.getHostByName("www.plot.ly", &ip))  {
           Serial.println(F("Couldn't resolve!"));
         }
         delay(500);
@@ -142,9 +142,9 @@ bool plotly::init(){
                 c = client.read();
 
                 Serial.print(c);
+                client.close();
             }
         }
-        client.close();
     }
     return true;
 


### PR DESCRIPTION
remove \n from line 45 so address resolves

move client.close() inside the if(Client.available()) loop so it doesn't hang